### PR TITLE
AV-1397 - Emails - Limit Setting - System is just checking the emails…

### DIFF
--- a/lib/acts_as_limitable/limitable.rb
+++ b/lib/acts_as_limitable/limitable.rb
@@ -119,9 +119,11 @@ module ActsAsLimitable
           Rails.logger.debug {"ActsAsLimitable: guarding #{m} unless \#{amount} are available"}
           owner_id = (owner.respond_to?(:id) ? owner.id : owner.to_s) rescue "public"
           if ActsAsLimitable.check_limit_multi("#{aspect}", owner_id, limits: limits, amount: amount)
-            ActsAsLimitable.incr_bucket_vals("#{aspect}", owner_id, limits: limits, amount: amount)
             Rails.logger.debug {"ActsAsLimitable: allowed call to #{m}"}
-            send :#{old_method}, *args, &block
+            result = send(:#{old_method}, *args, &block)
+            if (!!result == result && result) || (result.singleton_class.include?(ActiveModel::Validations) && result.errors.none?)
+              ActsAsLimitable.incr_bucket_vals("#{aspect}", owner_id, limits: limits, amount: amount)
+            end
           end
         end
         END

--- a/lib/acts_as_limitable/limitable.rb
+++ b/lib/acts_as_limitable/limitable.rb
@@ -124,6 +124,7 @@ module ActsAsLimitable
             if (!!result == result && result) || (result.singleton_class.include?(ActiveModel::Validations) && result.errors.none?)
               ActsAsLimitable.incr_bucket_vals("#{aspect}", owner_id, limits: limits, amount: amount)
             end
+            result
           end
         end
         END

--- a/spec/extras/models.rb
+++ b/spec/extras/models.rb
@@ -25,9 +25,9 @@ module TestMethods
     base.extend ClassMethods                                                                                                                                                  
   end
 
-  def limited1;puts "limited1";end
-  def limited2;puts "limited2";end
-  def not_limited;print ".";end
+  def limited1;puts "limited1";true;end
+  def limited2;puts "limited2";true;end
+  def not_limited;print ".";true;end
 end
 
 
@@ -96,10 +96,12 @@ class LimitableModel < ActiveRecord::Base
 
   def limited_by_args_val params = {}
     puts 'This will be marked up to always require 10,000 units in order to run'
+    true
   end
 
   def extremely_restricted
     puts "extremely_restricted"
+    true
   end
 
   limitable_methods :limited1, :limited2, :static_method


### PR DESCRIPTION
… tried sending but not successful sent outs

Logic is that check_limit_multi has already determined that we're not exceeding any limits so we can wait until after we've sent the emails before incrementing the count. Expect that the return value from the old method is a boolean or an activerecord instance and make sure it's either true or has no errors, respectively.
